### PR TITLE
Fix first achievement bug

### DIFF
--- a/Assets/NewgroundsUnityAPIHelper/Helper/Scripts/MedalController.cs
+++ b/Assets/NewgroundsUnityAPIHelper/Helper/Scripts/MedalController.cs
@@ -32,7 +32,7 @@ namespace NewgroundsUnityAPIHelper.Helper.Scripts
             var request = new io.newgrounds.components.Medal.unlock { id = id };
             request.callWith(_core, result =>
             {
-                _allMedals[result.medal.id] = result.medal;
+                _allMedals.Find(medal => medal.id == id).unlocked = true;
                 onUnlock(result);
             });
         }


### PR DESCRIPTION
Hi Facundo, firstly thank you for making this awesome tool, I've found it very useful!

I recently ran into an odd bug, but I think I have a fix for it.

<br>

**Bug description:** Trying to unlock the first achievement in `_allMedals` after another achievement has already been unlocked, results in an error. Trying to unlock the first achievement twice also results in the same error.

I think the culprit is within the Unlock method in MedalController.cs, where presumably the medal attributes are being updated after being unlocked.

This doesn't work as intended because:
 - The medal id is not an index.
 - The `result` medal object isn't initialised, and so its id is the default 0.
 
This causes the first medal in `_allMedals` to be overwritten with a default-initialised medal. This leads to any subsequent calls of unlocking the first medal to fail at the `GetMedal` stage.

<br>

**Fix:** Remove the erroneous indexing and just update the relevant medal's `unlocked` attribute to true. 

There might be a better way of doing this instead of using a Find(), but I think this gives the behaviour we'd want.